### PR TITLE
Hint for displaying whole working directory

### DIFF
--- a/parrot.zsh-theme
+++ b/parrot.zsh-theme
@@ -3,6 +3,10 @@
 # It is recommended to use with a dark background.
 # Colors: black, red, green, yellow, *blue, magenta, cyan, and white.
 #
+# Note: If you change %c% in line
+# 	%{$terminfo[bold]$fg[yellow]%}%c%{$reset_color%}\
+# to %~% it will display the whole working directory
+#
 # Feb 2022 TOURE A. KARIM
 
 # VCS


### PR DESCRIPTION
Hello TOURE A. KARIM,
first of all:
Thanks a lot for this great theme. This was exactly what I was looking for. I liked it a lot in the parrot os and therefore wanted to inlcude this also in my main os.

I have here a suggestion to make a hint or a note about what to change if you like to see the whole directory.

So that it looks like this:
![image](https://user-images.githubusercontent.com/63300156/221684048-ac9c7217-4da2-4e4b-a808-a954c8f3a7e8.png)

I personally like this more since I'm often in directories which only have the name build or src and than its hard to see where I am.

I know that not all of the users want this thats why I left it as a note/tipp at the top.
You can merge if you like maybe its also helping other people.

Thanks a lot for your work.
Many greetings
Florian
